### PR TITLE
Enable Next.js static export and refactor accordingly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dependencies step to avoid rebuilds if the package.json or package-lock.json have not changed.
-FROM node:18-alpine as BUILD-DEPS
+FROM node:20-alpine as BUILD-DEPS
 
 WORKDIR /mtsu-deps
 COPY --chown=node:node package.json package-lock.json ./

--- a/app/g/[...slug]/page.tsx
+++ b/app/g/[...slug]/page.tsx
@@ -1,42 +1,12 @@
+"use client"
 import { Metadata } from "next"
-import { APIPathsV1, fetchJSON, getCacheUrl } from "../../../lib/api/other"
-import { changeExtension, clamp } from "../../../lib/helpers"
-import { Gallery } from "../../../types/api"
 import GalleryPage from "./gallery"
-
-export const getGallery = async (slug: string) => {
-  const slugs = slug
-  if (!slugs || slugs.length === 0) {
-    return null
-  }
-
-  const gallery: Gallery = await fetchJSON(`${APIPathsV1.Gallery}${slugs[0]}`)
-  if (!gallery) {
-    return null
-  }
-
-  if (!gallery.Files) {
-    gallery.Files = []
-  }
-
-  const thumbnails: string[] = []
-  gallery.Files.forEach((file, i) => {
-    thumbnails.push(getCacheUrl(`/thumbnails/${gallery.Meta.UUID}/${changeExtension(file, ".webp")}`))
-    gallery.Files[i] = getCacheUrl(`/${gallery.Meta.UUID}/${file}`)
-  })
-
-  return {
-    gallery,
-    thumbnails,
-    page: slugs.length > 1 ? clamp(parseInt(slugs[1]), 0, gallery.Count) : 0,
-  }
-}
 
 export const metadata: Metadata = {
   title: "Mangatsu | gallery",
   description: "Gallery",
 }
 
-export default async function Page() {
+export default function Page() {
   return <GalleryPage />
 }

--- a/app/series/[slug]/page.tsx
+++ b/app/series/[slug]/page.tsx
@@ -1,42 +1,6 @@
-import { Metadata } from "next"
-import { APIPathsV1, fetchJSON, getCacheUrl } from "../../../lib/api/other"
-import { changeExtension, clamp } from "../../../lib/helpers"
-import { Gallery } from "../../../types/api"
+"use client"
 import SeriesPage from "./series"
 
-export const getGalleries = async (slug: string) => {
-  const slugs = slug
-  if (!slugs || slugs.length === 0) {
-    return null
-  }
-
-  const gallery: Gallery = await fetchJSON(`${APIPathsV1.Gallery}${slugs[0]}`)
-  if (!gallery) {
-    return null
-  }
-
-  if (!gallery.Files) {
-    gallery.Files = []
-  }
-
-  const thumbnails: string[] = []
-  gallery.Files.forEach((file, i) => {
-    thumbnails.push(getCacheUrl(`/thumbnails/${gallery.Meta.UUID}/${changeExtension(file, ".webp")}`))
-    gallery.Files[i] = getCacheUrl(`/${gallery.Meta.UUID}/${file}`)
-  })
-
-  return {
-    gallery,
-    thumbnails,
-    page: slugs.length > 1 ? clamp(parseInt(slugs[1]), 0, gallery.Count) : 0,
-  }
-}
-
-export const metadata: Metadata = {
-  title: "Mangatsu | gallery",
-  description: "Gallery",
-}
-
-export default async function Page({ params }: { params: { slug: string } }) {
+export default function Page() {
   return <SeriesPage />
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,7 +24,7 @@ const nextConfig = {
     formats: ["image/webp"],
     minimumCacheTTL: 60 * 60 * 24 * 30,
   },
-  output: "standalone",
+  output: "export",
 }
 
 export default nextConfig


### PR DESCRIPTION
With being able to completely statically export the whole page to a client side lump, it would be possible to easily bundle it with the Mangatsu Server (Go backend) into a single binary file.
